### PR TITLE
Dotnet CVE scanning

### DIFF
--- a/.github/workflows/cve-scanning-dotnet.yml
+++ b/.github/workflows/cve-scanning-dotnet.yml
@@ -1,34 +1,38 @@
-# This workflow will scan a .NET project
-# For more information see: https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/#dotnet-cli
-
 name: CVE Scanning for .NET
 
 on:
-  schedule:
-    - cron: '0 8,18 * * 1-5'
   push:
-    paths:
-      - 'dotnet/*.csproj'
-      - '.github/workflows/cve-scanning-dotnet.yml'
 
 jobs:
-  scan:
+  dotnet-modules-scan:
+    name: dotnet-scan
     runs-on: ubuntu-latest
+    continue-on-error: false
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Build project
-      run: dotnet build
-      working-directory: dotnet
-    - name: Scan
-      run: dotnet list package --vulnerable --include-transitive | tee vulnerable.out
-      working-directory: dotnet
-    - name: Output result
-      run: cat vulnerable.out
-      working-directory: dotnet
-    - name: Parse result
-      run: test `grep -cm 1 'has the following vulnerable packages' vulnerable.out` = 1
-      working-directory: dotnet
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build project with dotnet
+        run: dotnet build --configuration Release
+        working-directory: dotnet
+      - name: List vulnerable libraries
+        run: dotnet list package --vulnerable --include-transitive
+        working-directory: 'dotnet'
+      - name: Depcheck
+        uses: dependency-check/Dependency-Check_Action@main
+        id: Depcheck
+        with:
+          project: 'dotnet'
+          path: 'dotnet'
+          format: 'HTML'
+          out: 'reports'
+          args: >
+            --suppression ./dotnet/allow-list.xml
+            --failOnCVSS 6
+            --enableRetired
+      - name: Upload Test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Depcheck report
+          path: ${{ github.workspace }}/reports

--- a/.github/workflows/cve-scanning-dotnet.yml
+++ b/.github/workflows/cve-scanning-dotnet.yml
@@ -28,7 +28,7 @@ jobs:
           out: 'reports'
           args: >
             --suppression ./dotnet/allow-list.xml
-            --failOnCVSS 6
+            --failOnCVSS 5
             --enableRetired
       - name: Upload Test results
         if: ${{ always() }}

--- a/dotnet/allow-list.xml
+++ b/dotnet/allow-list.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/dotnet/allow-list.xml
+++ b/dotnet/allow-list.xml
@@ -4,7 +4,6 @@
           <notes><![CDATA[
         Testing false positives by suppressing a CVE
         ]]></notes>
-    <filePath regex="true">.*\bsample-project-0\.0\.1\.jar/META-INF/maven/commons-fileupload/commons-fileupload/pom\.xml</filePath>
         <cve>CVE-2022-41064</cve>
     </suppress>
 </suppressions>

--- a/dotnet/allow-list.xml
+++ b/dotnet/allow-list.xml
@@ -1,3 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+      <suppress>
+          <notes><![CDATA[
+        Testing false positives by suppressing a CVE
+        ]]></notes>
+    <filePath regex="true">.*\bsample-project-0\.0\.1\.jar/META-INF/maven/commons-fileupload/commons-fileupload/pom\.xml</filePath>
+        <cve>CVE-2022-41064</cve>
+    </suppress>
 </suppressions>

--- a/dotnet/sample.csproj
+++ b/dotnet/sample.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/sample.csproj
+++ b/dotnet/sample.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.*" />
     <!-- <PackageReference Include="System.ServiceModel.Http" Version="4.10.*" /> -->
     <PackageReference Include="System.Threading.AccessControl" Version="6.0.*" />
-
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" /> <!--  CVE 2022-41064 -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changed cve-scanning-dotnet.yml to works with the DependencyCheck action

Added  ` <NoWarn>NU1605</NoWarn>` to avoid package downgrading error (to remove for real project) 

Creating allow-list.xml to skip CVE if we want to