### PR TITLE
Rust license scanning

### DIFF
--- a/.github/workflows/license-scanning-rust.yml
+++ b/.github/workflows/license-scanning-rust.yml
@@ -1,0 +1,24 @@
+name: License Scanning for Rust
+
+on:
+  schedule:
+    - cron: '0 8,18 * * 1-5'
+  push:
+    paths:
+      - 'rust/Cargo.toml'
+      - '.github/workflows/license-scanning-rust.yml'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
+        with:
+          toolchain: stable
+      - run: cargo install --force cargo-audit
+      - name: Install and run licensebat 
+        run: |
+          cargo add licensebat-cli
+          cargo run licensebat --dependency-file ~/rust/Cargo.lock --licrc-file ~/rust/license.licrc
+        working-directory: rust

--- a/rust/license.licrc
+++ b/rust/license.licrc
@@ -1,0 +1,35 @@
+[licenses]
+# This indicates which are the only licenses that Licensebat will accept.
+# The rest will be flagged as not allowed.
+accepted = ["MIT", "MSC", "BSD"]
+# This will indicate which licenses are not accepted.
+# The rest will be accepted, except for the unknown licenses or dependencies without licenses.
+# unaccepted = ["LGPL"]
+# Note that only one of the previous options can be enabled at once.
+# If both of them are informed, only accepted will be considered.
+
+[dependencies]
+# This will allow users to flag some dependencies so that Licensebat will not check for their license.
+ignored=["ignored_dep1", "ignored_dep2"]
+# False by default, if true it will mark all dev dependencies as ignored.
+# Bear in mind that this is only supported by some of the collectors.
+ignore_dev_dependencies = false
+# False by default, if true it will mark all optional dependencies as ignored.
+# Bear in mind that this is only supported by some of the collectors.
+ignore_optional_dependencies = false
+
+[behavior]
+# False by default (always exit code == 0), if true, it will exit with code 1 in case some invalid dependency is found.
+do_not_block_pr = false
+# False by default, if true it will do not show the ignored dependencies in the final report.
+do_not_show_ignored_dependencies = false
+# False by default, if true it will do not show the dev dependencies in the final report.
+# Bear in mind that this is only supported by some of the collectors.
+do_not_show_dev_dependencies = false
+# False by default, if true it will do not show the optional dependencies in the final report.
+# Bear in mind that this is only supported by some of the collectors.
+do_not_show_optional_dependencies = false
+# This will define the size of the buffer used to retrieve the dependencies.
+# It's set to 100 by default.
+# If you have a lot of dependencies, you might want to increase this value, but be careful, if the size is too big, the API might return an error.
+retriever_buffer_size = 100


### PR DESCRIPTION
Adding license scanning for Rust using [licensebat-cli](https://github.com/licensebat/licensebat/tree/master/licensebat-cli)