### PR TITLE
[#313] Standardized and upgraded GitHub Actions workflows for vulnerability scanning pipelines

### DIFF
--- a/.github/workflows/cve-scanning-docker.yml
+++ b/.github/workflows/cve-scanning-docker.yml
@@ -12,12 +12,12 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker-practice/actions-setup-docker@321477a1e481dd60b05f9b489cf4b9be467aa15c
       - name: Build
         run: docker build -f Dockerfile -t user/app:latest .
         working-directory: docker
       - name: Scan for vulnerabilities
-        uses: crazy-max/ghaction-container-scan@dfa7e54dc32045120f06d0bc8d7724860f5db0ad
+        uses: crazy-max/ghaction-container-scan@v3
         with:
           image: user/app:latest

--- a/.github/workflows/cve-scanning-dotnet.yml
+++ b/.github/workflows/cve-scanning-dotnet.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build project with dotnet
         run: dotnet build --configuration Release
         working-directory: dotnet
@@ -19,7 +19,7 @@ jobs:
         run: dotnet list package --vulnerable --include-transitive
         working-directory: 'dotnet'
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c
         id: Depcheck
         with:
           project: 'dotnet'
@@ -32,7 +32,7 @@ jobs:
             --enableRetired
       - name: Upload Test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Depcheck report
           path: ${{ github.workspace }}/reports

--- a/.github/workflows/cve-scanning-gradle.yml
+++ b/.github/workflows/cve-scanning-gradle.yml
@@ -9,12 +9,12 @@ jobs:
     name: depecheck_test
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build project with Gradle
         run: gradle clean build
         working-directory: gradle
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c
         id: Depcheck
         with:
           project: 'gradle'
@@ -29,7 +29,7 @@ jobs:
             
       - name: Upload Test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Depcheck report
           path: ${{ github.workspace }}/reports

--- a/.github/workflows/cve-scanning-maven.yml
+++ b/.github/workflows/cve-scanning-maven.yml
@@ -9,9 +9,9 @@ jobs:
     name: depecheck_test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -19,7 +19,7 @@ jobs:
         run: mvn install 
         working-directory: maven
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c
         id: Depcheck
         env:
           JAVA_HOME: /opt/jdk
@@ -35,7 +35,7 @@ jobs:
             
       - name: Upload Test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Depcheck report
           path: ${{ github.workspace }}/reports

--- a/.github/workflows/cve-scanning-node.yml
+++ b/.github/workflows/cve-scanning-node.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Build project with NPM
         run: npm install --omit=dev
         working-directory: node
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c
         id: Depcheck
         with:
           project: 'node'
@@ -32,7 +32,7 @@ jobs:
             --enableRetired
       - name: Upload Test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Depcheck report
           path: ${{ github.workspace }}/reports

--- a/.github/workflows/cve-scanning-python.yml
+++ b/.github/workflows/cve-scanning-python.yml
@@ -17,11 +17,11 @@ jobs:
     name: Build and test App
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - uses: abatilo/actions-poetry@437d4fa27baf74d89b789ba2d8cae97dd2365feb
+      - uses: abatilo/actions-poetry@v3
         with:
           poetry-version: "1.2.2"
       - name: Install safety

--- a/.github/workflows/cve-scanning-rust.yml
+++ b/.github/workflows/cve-scanning-rust.yml
@@ -12,8 +12,8 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
       - run: cargo install --force cargo-audit

--- a/.github/workflows/cve-scanning-scala.yml.disabled
+++ b/.github/workflows/cve-scanning-scala.yml.disabled
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 8

--- a/.github/workflows/license-scanning-dotnet.yml
+++ b/.github/workflows/license-scanning-dotnet.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build project with dotnet
         run: dotnet build --configuration Release
         working-directory: 'dotnet'

--- a/.github/workflows/license-scanning-gradle.yml
+++ b/.github/workflows/license-scanning-gradle.yml
@@ -9,10 +9,10 @@ jobs:
     name: License Scan
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/license-scanning-maven.yml
+++ b/.github/workflows/license-scanning-maven.yml
@@ -16,9 +16,9 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 11
         cache: maven
@@ -39,7 +39,7 @@ jobs:
         if [ $LINES_FOUND -gt 1 ]; then echo $LICENSE_REPORT ; exit -1; fi
       working-directory: maven
     - name: Upload license XML reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: license-xml-report
         path: 'maven/**/${{ env.REPORT_PATH }}'

--- a/.github/workflows/license-scanning-node.yml
+++ b/.github/workflows/license-scanning-node.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci --prod

--- a/.github/workflows/license-scanning-python.yml
+++ b/.github/workflows/license-scanning-python.yml
@@ -18,8 +18,8 @@ jobs:
     name: Scan for licenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install pip-licenses

--- a/.github/workflows/license-scanning-rust.yml
+++ b/.github/workflows/license-scanning-rust.yml
@@ -12,8 +12,8 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
       - run: cargo install --force cargo-audit

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -18,8 +18,8 @@ jobs:
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
-      image: returntocorp/semgrep
+      image: semgrep/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: semgrep ci


### PR DESCRIPTION
Closes #313

Standardized and upgraded GitHub Actions versions across all workflow files in .github/workflows/ to address outdated and deprecated actions, improving security posture and long-term maintainability of the scanning pipelines (e.g., Grype, Trivy), improving security posture and maintainability


Changes:

actions/checkout → v4
actions/setup-java → v4
actions/setup-node → v4
actions/setup-python → v5
actions/upload-artifact → v4 (v1/v2/v3 deprecated)
actions-rs/toolchain → actions-rust-lang/setup-rust-toolchain@v1 (archived Oct 2023)
dependency-check/Dependency-Check_Action → latest commit SHA (Dec 2025)
abatilo/actions-poetry → v3
crazy-max/ghaction-container-scan → v3
returntocorp/semgrep container image → semgrep/semgrep (official migration)


Testing: All workflow files validated for correct YAML syntax locally.