### PR TITLE
[#311] Integrate dependency-review-action into code scanning workflows

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: runtime
+          comment-summary-in-pr: always


### PR DESCRIPTION
Closes #311

Adds actions/dependency-review-action@v4 as a new workflow to the code scanning pipeline. The action scans pull requests for dependency changes and fails if any newly introduced dependency has a known vulnerability or disallowed license.

Addressing the question in the issue - what languages, builds and frameworks are supported:
The dependency-review-action is powered by the GitHub dependency graph, which supports the following ecosystems present in this repo:
- Java via Maven (pom.xml) and Gradle
- JavaScript via npm (package-lock.json)
- Python via pip and Poetry (poetry.lock)
- Rust via Cargo (Cargo.lock)
- .NET via NuGet (.csproj)
- Scala via Maven/Gradle

Configuration:
- fail-on-severity set to moderate, aligned with the existing failOnCVSS 5 threshold across other workflows
- fail-on-scopes set to runtime, consistent with existing behaviour of skipping dev dependencies
- comment-summary-in-pr set to always, surfaces scan results directly in the PR

Testing:
All workflow files validated for correct YAML syntax locally.